### PR TITLE
fix: filtrar avaliação de desempate por status SENT

### DIFF
--- a/src/core/EvaluationMethod.php
+++ b/src/core/EvaluationMethod.php
@@ -344,7 +344,11 @@ abstract class EvaluationMethod extends Module implements \JsonSerializable{
     function getTiebreakerEvaluation(Entities\Registration $registration) {
         $app = App::i();
 
-        $tiebreaker_evaluations = $app->repo('RegistrationEvaluation')->findOneBy(['registration' => $registration, 'isTiebreaker' => true]);
+        $tiebreaker_evaluations = $app->repo('RegistrationEvaluation')->findOneBy([
+            'registration' => $registration,
+            'isTiebreaker' => true,
+            'status' => RegistrationEvaluation::STATUS_SENT
+        ]);
 
         if(empty($tiebreaker_evaluations)){
             return null;


### PR DESCRIPTION
Impede que rascunhos sejam usados como resultado de desempate.

(cherry picked from commit 970f32c4e7f3e4a06bd086d3ccacbd64079a172f)