### PR TITLE
Corrige erro na tela de configuração de fases da oportunidade que impedia a listagem e o gerenciamento das fases quando havia fases de avaliação

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ Todas as mudanças notáveis no projeto serão documentadas neste arquivo.
 O formato é baseado no [Keep a Changelog](https://keepachangelog.com/pt-BR/1.0.0/)
 e este projeto adere ao [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+### Correções
+- Corrige a listagem de fases da oportunidade para exibir corretamente fases de avaliação na configuração
+
 ## [7.8.0] - 2026-07-02
 ### Novas Funcionalidades
 - Módulo de **fase de execução** para acompanhar projetos aprovados após o resultado. O agente contemplado pode abrir pedidos de alteração (data, orçamento, local etc.), cada um avaliado por uma comissão. Os pedidos ficam registrados no histórico e não atrapalham as fases seguintes de prestação de informações

--- a/src/modules/OpportunityPhases/Module.php
+++ b/src/modules/OpportunityPhases/Module.php
@@ -851,7 +851,7 @@ class Module extends \MapasCulturais\Module{
 
                         $app->applyHook('module(OpportunityPhases).evaluationPhaseData', [&$mout_simplify]);
 
-                        $item = $emc->simplify("{$mout_simplify},opportunity,infos,evaluationFrom,evaluationTo,relatedAgents,agentRelations");
+                        $item = $emc->simplify("{$mout_simplify},type,opportunity,infos,evaluationFrom,evaluationTo,relatedAgents,agentRelations");
                         if($appeal_phase = $emc->appealPhase) {
                             $item->appealPhase = $appeal_phase;
                             $item->opportunity = $opportunity->simplify('id,isFirstPhase,isLastPhase,isReportingPhase,isLastReportingPhase,isContinuousFlow,hasEndDate,files,statusLabels,relatedAgents,agentRelations');

--- a/tests/src/OpportunityPhasesTest.php
+++ b/tests/src/OpportunityPhasesTest.php
@@ -34,6 +34,37 @@ class OpportunityPhasesTest extends TestCase
     private const REGISTRATION_MODEL_TEST_STEP_NAMES = ['Etapa 1', 'Etapa 2', 'Etapa 3', 'Etapa 4'];
 
 
+    function testPhasesIncludesEvaluationTypeForConfigRendering(): void
+    {
+        $admin = $this->userDirector->createUser('admin');
+        $this->login($admin);
+
+        /** @var Opportunity */
+        $opportunity = $this->opportunityBuilder
+            ->reset(owner: $admin->profile, owner_entity: $admin->profile)
+            ->fillRequiredProperties()
+            ->firstPhase()
+                ->setRegistrationPeriod(new Open)
+                ->done()
+            ->save()
+            ->addEvaluationPhase(EvaluationMethods::simple)
+                ->setEvaluationPeriod(new ConcurrentEndingAfter)
+                ->save()
+                ->done()
+            ->refresh()
+            ->getInstance();
+
+        $phases = $opportunity->phases;
+        $evaluation_phase = array_values(array_filter($phases, function ($phase) {
+            return isset($phase->evaluationFrom, $phase->evaluationTo);
+        }))[0] ?? null;
+
+        $this->assertNotNull($evaluation_phase, 'Garantindo que a lista de fases contenha uma fase de avaliação');
+        $this->assertObjectHasProperty('type', $evaluation_phase, 'Garantindo que a fase de avaliação traga o tipo usado pelo template');
+        $this->assertEquals('simple', $evaluation_phase->type->id);
+        $this->assertNotEmpty($evaluation_phase->type->name);
+    }
+
     /**
      * Garante que, após excluir a primeira fase de avaliação, a segunda fase de avaliação permaneça vinculada à primeira fase de coleta de dados.
      */


### PR DESCRIPTION
## Resumo

Corrige erro na tela de configuração de fases da oportunidade que impedia a listagem e o gerenciamento das fases quando havia fases de avaliação.

A API `opportunity.phases` retornava as configurações de avaliação sem o campo `type`, mas o template da configuração acessava `item.type.name`. Com isso, o render do Vue quebrava e a listagem de fases não aparecia corretamente.

## Erro observado

```txt
components.1jlfgos.js:2 TypeError: Cannot read properties of undefined (reading 'name')
    at eval (eval at mp (components.1jlfgos.js:2:383059), <anonymous>:133:100)
```
