### PR TITLE
Cria oportunidades a partir de modelos sem copiar as datas das fases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ e este projeto adere ao [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 ## [Unreleased]
 ### Correções
 - Corrige a listagem de fases da oportunidade para exibir corretamente fases de avaliação na configuração
+- Corrige o uso de modelos de oportunidades para criar novas oportunidades sem copiar as datas das fases
 
 ## [7.8.0] - 2026-07-02
 ### Novas Funcionalidades

--- a/src/core/Traits/EntityManagerModel.php
+++ b/src/core/Traits/EntityManagerModel.php
@@ -3,6 +3,7 @@ namespace MapasCulturais\Traits;
 
 use MapasCulturais\App;
 use MapasCulturais\Entity;
+use MapasCulturais\Entities\EvaluationMethodConfiguration;
 use MapasCulturais\Entities\Opportunity;
 use MapasCulturais\Entities\RegistrationStep;
 
@@ -105,8 +106,8 @@ trait EntityManagerModel {
         try {
             $this->entityOpportunityModel = $this->generateOpportunity();
 
-            $this->generateEvaluationMethods();
-            $this->generatePhases();
+            $this->generateEvaluationMethods(false);
+            $this->generatePhases(false);
             $this->generateTerms();
             $this->generateMetadata(0, 0);
             $this->generateRegistrationFieldsAndFiles($this->entityOpportunity, $this->entityOpportunityModel);
@@ -303,6 +304,7 @@ trait EntityManagerModel {
         
         $this->entityOpportunityModel = clone $this->entityOpportunity;
         $this->resetClonedEvaluationMethodConfiguration($this->entityOpportunityModel);
+        $this->clearOpportunityPhaseDates($this->entityOpportunityModel);
         $this->entityOpportunityModel->name = $name;
         $this->entityOpportunityModel->status = Entity::STATUS_DRAFT;
         $this->entityOpportunityModel->owner = $app->user->profile;
@@ -357,7 +359,7 @@ trait EntityManagerModel {
      * @return void
      * @access private
      */
-    private function generateEvaluationMethods() : void
+    private function generateEvaluationMethods(bool $copyDates = true) : void
     {
         $app = App::i();
 
@@ -368,6 +370,9 @@ trait EntityManagerModel {
         foreach ($evaluationMethodConfigurations as $evaluationMethodConfiguration) {
             $newMethodConfiguration = clone $evaluationMethodConfiguration;
             $newMethodConfiguration->setOpportunity($this->entityOpportunityModel);
+            if (!$copyDates) {
+                $this->clearEvaluationDates($newMethodConfiguration);
+            }
             $newMethodConfiguration->save(true);
 
             // duplica os metadados das configurações do modelo de avaliação
@@ -384,7 +389,7 @@ trait EntityManagerModel {
      * @return void
      * @access private
      */
-    private function generatePhases() : void
+    private function generatePhases(bool $copyDates = true) : void
     {
         $app = App::i();
         $postData = $this->postData;
@@ -406,6 +411,9 @@ trait EntityManagerModel {
 
             $newPhase = clone $phase;
             $this->resetClonedEvaluationMethodConfiguration($newPhase);
+            if (!$copyDates) {
+                $this->clearOpportunityPhaseDates($newPhase);
+            }
             $newPhase->setParent($this->entityOpportunityModel);
             $newPhase->owner = $app->user->profile;
 
@@ -432,6 +440,9 @@ trait EntityManagerModel {
             foreach ($evaluationMethodConfigurations as $evaluationMethodConfiguration) {
                 $newMethodConfiguration = clone $evaluationMethodConfiguration;
                 $newMethodConfiguration->setOpportunity($newPhase);
+                if (!$copyDates) {
+                    $this->clearEvaluationDates($newMethodConfiguration);
+                }
                 $newMethodConfiguration->save(true);
 
                 foreach ($evaluationMethodConfiguration->getMetadata() as $metadataKey => $metadataValue) {
@@ -441,15 +452,19 @@ trait EntityManagerModel {
             }
         }
 
-        if ($publishDate !== null) {
+        if ($publishDate !== null || !$copyDates) {
             $newPhases = $app->repo('Opportunity')->findBy([
                 'parent' => $this->entityOpportunityModel
             ]);
 
             foreach ($newPhases as $newPhase) {
                 if ($newPhase->getMetadata('isLastPhase')) {
-                    $newPhase->setPublishTimestamp($publishDate);
                     $newPhase->subsite = $publishSubsite;
+                    if ($copyDates) {
+                        $newPhase->setPublishTimestamp($publishDate);
+                    } else {
+                        $this->clearOpportunityPhaseDates($newPhase);
+                    }
                     $newPhase->save(true);
                     $this->changeObjectType($newPhase->id);
                     break;
@@ -471,6 +486,20 @@ trait EntityManagerModel {
         if (is_object($opportunity->__magicGetterCache ?? null)) {
             unset($opportunity->__magicGetterCache->evaluationMethodConfiguration);
         }
+    }
+
+    private function clearOpportunityPhaseDates(Opportunity $opportunity): void
+    {
+        $opportunity->registrationFrom = null;
+        $opportunity->registrationTo = null;
+        $opportunity->publishTimestamp = null;
+        $opportunity->autoPublish = false;
+    }
+
+    private function clearEvaluationDates(EvaluationMethodConfiguration $configuration): void
+    {
+        $configuration->evaluationFrom = null;
+        $configuration->evaluationTo = null;
     }
 
 

--- a/tests/src/OpportunityModelUsageTest.php
+++ b/tests/src/OpportunityModelUsageTest.php
@@ -176,6 +176,76 @@ class OpportunityModelUsageTest extends TestCase
         );
     }
 
+    function testOpportunityGeneratedFromModelDoesNotCopyPhaseDates(): void
+    {
+        $owner = $this->userDirector->createUser();
+
+        $this->login($owner);
+        $builder = $this->opportunityBuilder
+            ->reset(owner: $owner->profile, owner_entity: $owner->profile)
+            ->fillRequiredProperties()
+            ->firstPhase()
+                ->setRegistrationPeriod(new Open)
+                ->done()
+            ->save();
+
+        $builder->addEvaluationPhase(EvaluationMethods::simple)
+            ->setEvaluationPeriod(new ConcurrentEndingAfter)
+            ->setAutoPublish()
+            ->save()
+            ->done();
+
+        $additionalPhase = $builder->addDataCollectionPhase()
+            ->setRegistrationPeriod(new Open)
+            ->getInstance();
+        $additionalPhase->publishTimestamp = new \DateTime('+ 1 month');
+        $additionalPhase->autoPublish = true;
+        $additionalPhase->save(true);
+
+        $source = $builder->refresh()->getInstance();
+        $source->lastPhase->publishTimestamp = new \DateTime('+ 2 months');
+        $source->lastPhase->save(true);
+
+        $model = $this->generateModelFromOpportunity(
+            $source,
+            'Modelo com datas ' . uniqid('', true)
+        );
+        $model->setMetadata('isModelPublic', 1);
+        $model->save(true);
+        $model = $model->refreshed();
+
+        $this->assertSame($this->getPhaseDates($source->refreshed()), $this->getPhaseDates($model));
+
+        $model->lastPhase->autoPublish = true;
+        $model->lastPhase->save(true);
+        $model = $model->refreshed();
+        $modelPhaseDates = $this->getPhaseDates($model);
+
+        $this->assertNotNull($model->registrationFrom);
+        $this->assertNotNull($model->registrationTo);
+        $this->assertNotNull($model->evaluationMethodConfiguration->evaluationFrom);
+        $this->assertNotNull($model->evaluationMethodConfiguration->evaluationTo);
+        $this->assertNotNull($model->lastPhase->publishTimestamp);
+        $this->assertTrue($model->autoPublish);
+
+        $generated = $this->generateOpportunity($model, $owner->profile->id)->refreshed();
+
+        $this->assertCount(count($model->allPhases), $generated->allPhases);
+        foreach ($generated->allPhases as $phase) {
+            $this->assertNull($phase->registrationFrom);
+            $this->assertNull($phase->registrationTo);
+            $this->assertNull($phase->publishTimestamp);
+            $this->assertFalse($phase->autoPublish);
+
+            if ($configuration = $phase->evaluationMethodConfiguration) {
+                $this->assertNull($configuration->evaluationFrom);
+                $this->assertNull($configuration->evaluationTo);
+            }
+        }
+
+        $this->assertSame($modelPhaseDates, $this->getPhaseDates($model->refreshed()));
+    }
+
     private function createModel($owner, bool $isPublic): Opportunity
     {
         $this->login($owner);
@@ -247,5 +317,20 @@ class OpportunityModelUsageTest extends TestCase
             $opportunity->allPhases,
             fn(Opportunity $phase) => $phase->isDataCollection && !$phase->isLastPhase
         ));
+    }
+
+    private function getPhaseDates(Opportunity $opportunity): array
+    {
+        return array_map(
+            static fn(Opportunity $phase) => [
+                'registrationFrom' => $phase->registrationFrom?->format('Y-m-d H:i:s'),
+                'registrationTo' => $phase->registrationTo?->format('Y-m-d H:i:s'),
+                'publishTimestamp' => $phase->publishTimestamp?->format('Y-m-d H:i:s'),
+                'autoPublish' => $phase->autoPublish,
+                'evaluationFrom' => $phase->evaluationMethodConfiguration?->evaluationFrom?->format('Y-m-d H:i:s'),
+                'evaluationTo' => $phase->evaluationMethodConfiguration?->evaluationTo?->format('Y-m-d H:i:s'),
+            ],
+            $opportunity->allPhases
+        );
     }
 }


### PR DESCRIPTION
# Cria oportunidades a partir de modelos sem copiar as datas das fases

## Contexto

Atualmente, ao criar uma oportunidade usando um modelo, todas as datas configuradas nas fases do modelo são copiadas para a nova oportunidade.

Esse comportamento tem causado problemas no **Cult Editais, plataforma do Ministério da Cultura**, pois a nova oportunidade herda um cronograma que pertence ao edital usado como modelo. Com isso, o gestor precisa revisar e remover manualmente as datas antes de definir o novo cronograma.

O sistema já permite oportunidades sem datas nas fases por meio da exportação e importação com a opção **“Datas das fases”** desmarcada.

## Solução

Este PR altera o fluxo de uso de modelos para que a nova oportunidade seja criada sem copiar:

- datas inicial e final das inscrições;
- datas inicial e final das avaliações;
- datas de publicação das fases;
- configuração de publicação automática.

As datas permanecem preservadas no modelo original. A alteração afeta somente a criação de uma oportunidade pelo botão **“Usar modelo”**. O fluxo de salvar uma oportunidade como modelo continua copiando suas configurações normalmente.

## Testes

Foi adicionado um teste de regressão cobrindo:

- primeira fase;
- fases adicionais;
- fases de avaliação;
- fase final;
- publicação automática;
- preservação das datas no modelo original;
- manutenção da estrutura de fases.

### Resultado

`OK (7 tests, 33 assertions)`