### PR TITLE
Corrige a exibição da data de publicação dos resultados em fases de avaliação consecutivas que possuem fase de recurso

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ e este projeto adere ao [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 ## [Unreleased]
 ### Correções
 - Corrige a listagem de fases da oportunidade para exibir corretamente fases de avaliação na configuração
+- Corrige a exibição da data de publicação em fases de avaliação consecutivas que possuem fase de recurso
 
 ## [7.8.0] - 2026-07-02
 ### Novas Funcionalidades

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ Todas as mudanças notáveis no projeto serão documentadas neste arquivo.
 O formato é baseado no [Keep a Changelog](https://keepachangelog.com/pt-BR/1.0.0/)
 e este projeto adere ao [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+### Correções
+- Corrige a listagem de fases da oportunidade para exibir corretamente fases de avaliação na configuração
+
 ## [7.8.0] - 2026-07-02
 ### Novas Funcionalidades
 - Módulo de **fase de execução** para acompanhar projetos aprovados após o resultado. O agente contemplado pode abrir pedidos de alteração (data, orçamento, local etc.), cada um avaliado por uma comissão. Os pedidos ficam registrados no histórico e não atrapalham as fases seguintes de prestação de informações

--- a/src/modules/Opportunities/components/opportunity-phases-config/script.js
+++ b/src/modules/Opportunities/components/opportunity-phases-config/script.js
@@ -103,14 +103,13 @@ app.component('opportunity-phases-config', {
         },
 
         showPublishTimestamp(phase) {
-            const previousPhase = this.getPreviousPhase(phase);
             const nextPhase = this.getNextPhase(phase);
 
             if (phase.isLastPhase) {
                 return true;
             } else if (phase.__objectType == 'opportunity' && nextPhase?.__objectType != 'evaluationmethodconfiguration' && phase.publishTimestamp) {
                 return true;
-            } else if (phase.__objectType == 'evaluationmethodconfiguration' && previousPhase.__objectType == 'opportunity' && previousPhase.publishTimestamp) {
+            } else if (phase.__objectType == 'evaluationmethodconfiguration' && phase.opportunity.publishTimestamp) {
                 return true;
             } else {
                 return false;

--- a/src/modules/OpportunityPhases/Module.php
+++ b/src/modules/OpportunityPhases/Module.php
@@ -854,7 +854,7 @@ class Module extends \MapasCulturais\Module{
                         $item = $emc->simplify("{$mout_simplify},type,opportunity,infos,evaluationFrom,evaluationTo,relatedAgents,agentRelations");
                         if($appeal_phase = $emc->appealPhase) {
                             $item->appealPhase = $appeal_phase;
-                            $item->opportunity = $opportunity->simplify('id,isFirstPhase,isLastPhase,isReportingPhase,isLastReportingPhase,isContinuousFlow,hasEndDate,files,statusLabels,relatedAgents,agentRelations');
+                            $item->opportunity = $opportunity->simplify('id,publishTimestamp,isFirstPhase,isLastPhase,isReportingPhase,isLastReportingPhase,isContinuousFlow,hasEndDate,files,statusLabels,relatedAgents,agentRelations');
                             $item->opportunity->appealPhase = (object) $appeal_phase->jsonSerialize();
                             $item->opportunity->appealPhase->relatedAgents = $appeal_phase->relatedAgents;
                             $item->opportunity->appealPhase->agentRelations = $appeal_phase->agentRelations;

--- a/src/modules/OpportunityPhases/Module.php
+++ b/src/modules/OpportunityPhases/Module.php
@@ -851,7 +851,7 @@ class Module extends \MapasCulturais\Module{
 
                         $app->applyHook('module(OpportunityPhases).evaluationPhaseData', [&$mout_simplify]);
 
-                        $item = $emc->simplify("{$mout_simplify},opportunity,infos,evaluationFrom,evaluationTo,relatedAgents,agentRelations");
+                        $item = $emc->simplify("{$mout_simplify},type,opportunity,infos,evaluationFrom,evaluationTo,relatedAgents,agentRelations");
                         if($appeal_phase = $emc->appealPhase) {
                             $item->appealPhase = $appeal_phase;
                             $item->opportunity = $opportunity->simplify('id,isFirstPhase,isLastPhase,isReportingPhase,isLastReportingPhase,isContinuousFlow,hasEndDate,files,statusLabels,relatedAgents,agentRelations');

--- a/tests/js/opportunity-phases-config.test.mjs
+++ b/tests/js/opportunity-phases-config.test.mjs
@@ -1,0 +1,46 @@
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import test from 'node:test';
+import vm from 'node:vm';
+
+const source = readFileSync(
+    new URL('../../src/modules/Opportunities/components/opportunity-phases-config/script.js', import.meta.url),
+    'utf8'
+);
+
+let component;
+vm.runInNewContext(source, {
+    app: {
+        component(name, definition) {
+            if (name === 'opportunity-phases-config') {
+                component = definition;
+            }
+        },
+    },
+    $TEMPLATES: { 'opportunity-phases-config': '' },
+    Entity: class Entity {},
+    Utils: { getTexts: () => () => '' },
+});
+
+test('shows the publication date of a consecutive evaluation phase', () => {
+    const firstPhase = { __objectType: 'opportunity' };
+    const firstEvaluation = {
+        __objectType: 'evaluationmethodconfiguration',
+        opportunity: { publishTimestamp: null },
+    };
+    const secondEvaluation = {
+        __objectType: 'evaluationmethodconfiguration',
+        opportunity: { publishTimestamp: { date: '2030-01-15 12:30:00' } },
+    };
+    const lastPhase = { __objectType: 'opportunity', isLastPhase: true };
+    const context = {
+        phases: [firstPhase, firstEvaluation, secondEvaluation, lastPhase],
+    };
+    context.getPreviousPhase = (phase) => component.methods.getPreviousPhase.call(context, phase);
+    context.getNextPhase = (phase) => component.methods.getNextPhase.call(context, phase);
+
+    assert.equal(
+        component.methods.showPublishTimestamp.call(context, secondEvaluation),
+        true
+    );
+});

--- a/tests/src/OpportunityPhasesTest.php
+++ b/tests/src/OpportunityPhasesTest.php
@@ -65,6 +65,57 @@ class OpportunityPhasesTest extends TestCase
         $this->assertNotEmpty($evaluation_phase->type->name);
     }
 
+    function testPhasesIncludesEvaluationPublishTimestampWhenItHasAppealPhase(): void
+    {
+        $admin = $this->userDirector->createUser('admin');
+        $this->login($admin);
+
+        /** @var Opportunity $opportunity */
+        $opportunity = $this->opportunityBuilder
+            ->reset(owner: $admin->profile, owner_entity: $admin->profile)
+            ->fillRequiredProperties()
+            ->firstPhase()
+                ->setRegistrationPeriod(new Open)
+                ->done()
+            ->save()
+            ->addEvaluationPhase(EvaluationMethods::simple)
+                ->setEvaluationPeriod(new ConcurrentEndingAfter)
+                ->save()
+                ->done()
+            ->refresh()
+            ->getInstance();
+
+        $evaluation = $opportunity->evaluationMethodConfiguration;
+        $expectedPublishTimestamp = new \DateTime('2030-01-15 12:30:00');
+        $evaluation->opportunity->publishTimestamp = $expectedPublishTimestamp;
+        $evaluation->opportunity->save(true);
+
+        $className = $evaluation->opportunity->getSpecializedClassName();
+        $appealPhase = new $className();
+        $appealPhase->parent = $evaluation->opportunity;
+        $appealPhase->status = Opportunity::STATUS_APPEAL_PHASE;
+        $appealPhase->name = 'Recurso teste';
+        $appealPhase->ownerEntity = $evaluation->opportunity->ownerEntity;
+        $appealPhase->isDataCollection = true;
+        $appealPhase->isAppealPhase = true;
+        $appealPhase->save(true);
+
+        $evaluation->opportunity->appealPhase = $appealPhase;
+        $evaluation->opportunity->save(true);
+
+        $evaluationPhase = array_values(array_filter(
+            $opportunity->refreshed()->phases,
+            fn($phase) => ($phase->id ?? null) === $evaluation->id
+        ))[0] ?? null;
+
+        $this->assertNotNull($evaluationPhase);
+        $this->assertObjectHasProperty('publishTimestamp', $evaluationPhase->opportunity);
+        $this->assertSame(
+            $expectedPublishTimestamp->format('Y-m-d H:i:s'),
+            $evaluationPhase->opportunity->publishTimestamp->format('Y-m-d H:i:s')
+        );
+    }
+
     /**
      * Garante que, após excluir a primeira fase de avaliação, a segunda fase de avaliação permaneça vinculada à primeira fase de coleta de dados.
      */

--- a/tests/src/OpportunityPhasesTest.php
+++ b/tests/src/OpportunityPhasesTest.php
@@ -34,6 +34,37 @@ class OpportunityPhasesTest extends TestCase
     private const REGISTRATION_MODEL_TEST_STEP_NAMES = ['Etapa 1', 'Etapa 2', 'Etapa 3', 'Etapa 4'];
 
 
+    function testPhasesIncludesEvaluationTypeForConfigRendering(): void
+    {
+        $admin = $this->userDirector->createUser('admin');
+        $this->login($admin);
+
+        /** @var Opportunity */
+        $opportunity = $this->opportunityBuilder
+            ->reset(owner: $admin->profile, owner_entity: $admin->profile)
+            ->fillRequiredProperties()
+            ->firstPhase()
+                ->setRegistrationPeriod(new Open)
+                ->done()
+            ->save()
+            ->addEvaluationPhase(EvaluationMethods::simple)
+                ->setEvaluationPeriod(new ConcurrentEndingAfter)
+                ->save()
+                ->done()
+            ->refresh()
+            ->getInstance();
+
+        $phases = $opportunity->phases;
+        $evaluation_phase = array_values(array_filter($phases, function ($phase) {
+            return isset($phase->evaluationFrom, $phase->evaluationTo);
+        }))[0] ?? null;
+
+        $this->assertNotNull($evaluation_phase, 'Garantindo que a lista de fases contenha uma fase de avaliação');
+        $this->assertObjectHasProperty('type', $evaluation_phase, 'Garantindo que a fase de avaliação traga o tipo usado pelo template');
+        $this->assertEquals('simple', $evaluation_phase->type->id);
+        $this->assertNotEmpty($evaluation_phase->type->name);
+    }
+
     /**
      * Garante que, após excluir a primeira fase de avaliação, a segunda fase de avaliação permaneça vinculada à primeira fase de coleta de dados.
      */


### PR DESCRIPTION
## Descrição

Corrige a exibição da data de publicação dos resultados em fases de avaliação consecutivas que possuem fase de recurso.

## Problema

A data de publicação permanecia salva e era validada pelo backend, mas não era retornada corretamente para o frontend quando a fase de avaliação possuía recurso.

Com isso, a interface apresentava a data como vazia, enquanto a alteração de outras datas da fase retornava o erro:

> A data de publicação do resultado deve ser posterior à data de término da fase.

O problema deixava de ocorrer ao remover a fase posterior.

## Solução

- Inclui o `publishTimestamp` da oportunidade no retorno das fases de avaliação com recurso.
- Exibe a data de publicação pertencente à própria fase de avaliação.
- Trata corretamente fases de avaliação consecutivas.
- Mantém as validações cronológicas existentes no backend.
- Adiciona testes de regressão para backend e frontend.

## Como testar

1. Crie uma oportunidade com uma fase de coleta de dados.
2. Adicione duas fases de avaliação consecutivas.
3. Configure uma fase de recurso na última avaliação.
4. Informe uma data de publicação do resultado.
5. Recarregue a configuração das fases.
6. Verifique que a data de publicação continua visível.
7. Altere a data final da coleta de dados e confirme que não existe mais uma data persistida invisível na interface.
